### PR TITLE
Bitcore health check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /packer/bitcoind-gcp-raid-stage2.ign
 /packer/bitcoind-gcp-raid.ign
 /build-neon.sh
+.idea

--- a/scripts/check_health.sh
+++ b/scripts/check_health.sh
@@ -86,7 +86,7 @@ function compare_heights() {
         echo $(awk '{printf($1+1)}' ${TEMP_COUNTER_FILE}) > ${TEMP_COUNTER_FILE}
     elif [ "${bitcoin_core_height}" = "${bitcore_height}" ]; then
         # Reset counter file to 0
-        log_info "Heights match. Resetting counter file to 0"
+        log_info "Heights match. Setting counter file to 0"
         echo "0" > ${TEMP_COUNTER_FILE}
     fi
 

--- a/scripts/check_health.sh
+++ b/scripts/check_health.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/bash
+
+#
+# AUTHOR: Charlie Cantoni
+#
+# This script is intended to check the health of the bitcore docker container by comparing its
+# current blockchain height with that of the bitcoin_core docker container. If there's a
+# discrepancy, it means the bitcore container is falling behind likely due to memory creep.
+# In this scenario, this script restarts the bitcore container, allowing it to catch up.
+#
+
+# Exit on error
+set -e
+
+# Parses args
+function parse_args() {
+    while getopts "t:" opt; do
+        [[ ${OPTARG} == -* ]] && { OPTIND=$((--OPTIND)); continue; }
+        case "${opt}" in
+            t) RESTART_THRESHOLD=${OPTARG};;
+            *) usage;;
+        esac
+    done
+    shift $((OPTIND-1))
+}
+
+function usage() {
+    echo "Usage: check_health.sh [-<option> [<value>]]"
+    echo "  t <number> ; A number which sets the failure threshold of which to restart the bitcore docker container once passed"
+    exit 1
+}
+
+# Sets vars used throughout the script
+function set_vars() {
+    RESTART_THRESHOLD=${RESTART_THRESHOLD:-10}
+    BITCORE_CONTAINER=${BITCORE_CONTAINER:-bitcore}
+    BITCOIN_CORE_CONTAINER=${BITCOIN_CORE_CONTAINER:-bitcoin_core}
+    TEMP_COUNTER_FILE_BASE_NAME="bitcore-health-check"
+    TEMP_COUNTER_FILE=$(ls /tmp/${TEMP_COUNTER_FILE_BASE_NAME}.*)
+}
+
+function log_info() {
+    echo "$(date -u +%FT%T.%3NZ) | INFO: ${1}"
+}
+
+function log_warning() {
+    echo "$(date -u +%FT%T.%3NZ) | WARNING: ${1}"
+}
+
+function log_error() {
+    echo "$(date -u +%FT%T.%3NZ) | ERROR: ${1}"
+}
+
+# Create counter file for tracking the number of times bitcore has been observed as behind the bitcoin blockchain
+fuction create_counter_file() {
+    TEMP_COUNTER_FILE=$(mktemp /tmp/${TEMP_COUNTER_FILE_BASE_NAME}.XXXXX)
+    echo "0" > ${TEMP_COUNTER_FILE}
+}
+
+# Get the tmp counter file to use
+function get_counter_file() {
+    if [ $(echo ${TEMP_COUNTER_FILE} | wc -l) -gt 1 ]; then
+        log_warning "Multiple temp files found: ${TEMP_COUNTER_FILE}"
+        log_warning "Deleting them and creating a new temp file..."
+
+        for file in ${TEMP_COUNTER_FILE}; do
+            rm -f ${file}
+        done
+
+        create_counter_file
+    elif [ -z "${TEMP_COUNTER_FILE}" ]; then
+        log_info "Temp file doesn't exist. Creating new temp file..."
+        create_counter_file
+    fi
+}
+
+# Get blockchain heights. Iterate the counter file if the heights don't match. Otherwise, reset the counter to 0
+function compare_heights() {
+    BITCOIN_CORE_HEIGHT=$(docker logs ${BITCOIN_CORE_CONTAINER} --tail 100 | grep "height=" | cut -d '=' -f3 | awk '{print $1}' | tail -1)
+    BITCORE_HEIGHT=$(docker logs ${BITCORE_CONTAINER} --tail 100 | grep "height=" | cut -d '=' -f4 | tail -1)
+
+    # Compare blockchain heights
+    if [ "${BITCOIN_CORE_HEIGHT}" != "${BITCORE_HEIGHT}" ]; then
+        # Increment counter file by 1
+        echo $(awk '{printf($1+1)}' ${TEMP_COUNTER_FILE}) > ${TEMP_COUNTER_FILE}
+    elif [ "${BITCOIN_CORE_HEIGHT}" = "${BITCORE_HEIGHT}" ]; then
+        # Reset counter file to 0
+        echo "0" > ${TEMP_COUNTER_FILE}
+    fi
+
+    # Restart Bitcore docker container
+    if [ $(cat ${TEMP_COUNTER_FILE}) -ge ${RESTART_THRESHOLD} ]; then
+        log_info "Threshold met. Restarting Bitcore Docker container..."
+        docker restart ${BITCORE_CONTAINER}
+    fi
+}
+
+####################################
+########### SCRIPT START ###########
+####################################
+parse_args $@
+set_vars
+get_counter_file
+compare_heights
+####################################
+############ SCRIPT END ############
+####################################

--- a/scripts/check_health.sh
+++ b/scripts/check_health.sh
@@ -96,7 +96,7 @@ function compare_heights() {
         if [ ${blocks_behind_on_this_run} -gt ${blocks_behind_on_previous_run} ]; then
             sed -ri "s/([[:digit:]]),([[:digit:]])/\1,${blocks_behind_on_this_run}/g" ${TEMP_COUNTER_FILE}
 
-            # Restart Bitcore docker container if where past the failure threshold
+            # Restart Bitcore docker container if we're past the failure threshold
             if [ $(cat ${TEMP_COUNTER_FILE}) -ge ${RESTART_THRESHOLD} ]; then
                 log_info "Threshold met and we're falling further behind in blocks than previous execution. Restarting Bitcore Docker container..."
                 docker restart ${BITCORE_CONTAINER}

--- a/scripts/check_health.sh
+++ b/scripts/check_health.sh
@@ -36,7 +36,7 @@ function set_vars() {
     BITCORE_CONTAINER=${BITCORE_CONTAINER:-bitcore}
     BITCOIN_CORE_CONTAINER=${BITCOIN_CORE_CONTAINER:-bitcoin_core}
     TEMP_COUNTER_FILE_BASE_NAME="bitcore-health-check"
-    TEMP_COUNTER_FILE=$(ls /tmp/${TEMP_COUNTER_FILE_BASE_NAME}.*)
+    TEMP_COUNTER_FILE=$(ls /tmp/${TEMP_COUNTER_FILE_BASE_NAME}.* 2>/dev/null || echo '')
 }
 
 function log_info() {
@@ -52,7 +52,7 @@ function log_error() {
 }
 
 # Create counter file for tracking the number of times bitcore has been observed as behind the bitcoin blockchain
-fuction create_counter_file() {
+function create_counter_file() {
     TEMP_COUNTER_FILE=$(mktemp /tmp/${TEMP_COUNTER_FILE_BASE_NAME}.XXXXX)
     echo "0" > ${TEMP_COUNTER_FILE}
 }
@@ -82,9 +82,11 @@ function compare_heights() {
     # Compare blockchain heights
     if [ "${bitcoin_core_height}" != "${bitcore_height}" ]; then
         # Increment counter file by 1
+        log_info "Height discrepancy found. Incrementing counter file."
         echo $(awk '{printf($1+1)}' ${TEMP_COUNTER_FILE}) > ${TEMP_COUNTER_FILE}
     elif [ "${bitcoin_core_height}" = "${bitcore_height}" ]; then
         # Reset counter file to 0
+        log_info "Heights match. Resetting counter file to 0"
         echo "0" > ${TEMP_COUNTER_FILE}
     fi
 

--- a/scripts/check_health.sh
+++ b/scripts/check_health.sh
@@ -76,14 +76,14 @@ function get_counter_file() {
 
 # Get blockchain heights. Iterate the counter file if the heights don't match. Otherwise, reset the counter to 0
 function compare_heights() {
-    BITCOIN_CORE_HEIGHT=$(docker logs ${BITCOIN_CORE_CONTAINER} --tail 100 | grep "height=" | cut -d '=' -f3 | awk '{print $1}' | tail -1)
-    BITCORE_HEIGHT=$(docker logs ${BITCORE_CONTAINER} --tail 100 | grep "height=" | cut -d '=' -f4 | tail -1)
+    local bitcoin_core_height=$(docker logs ${BITCOIN_CORE_CONTAINER} --tail 100 | grep "height=" | cut -d '=' -f3 | awk '{print $1}' | tail -1)
+    local bitcore_height=$(docker logs ${BITCORE_CONTAINER} --tail 100 | grep "height=" | cut -d '=' -f4 | tail -1)
 
     # Compare blockchain heights
-    if [ "${BITCOIN_CORE_HEIGHT}" != "${BITCORE_HEIGHT}" ]; then
+    if [ "${bitcoin_core_height}" != "${bitcore_height}" ]; then
         # Increment counter file by 1
         echo $(awk '{printf($1+1)}' ${TEMP_COUNTER_FILE}) > ${TEMP_COUNTER_FILE}
-    elif [ "${BITCOIN_CORE_HEIGHT}" = "${BITCORE_HEIGHT}" ]; then
+    elif [ "${bitcoin_core_height}" = "${bitcore_height}" ]; then
         # Reset counter file to 0
         echo "0" > ${TEMP_COUNTER_FILE}
     fi

--- a/scripts/check_health.sh
+++ b/scripts/check_health.sh
@@ -54,7 +54,7 @@ function log_error() {
 # Create counter file for tracking the number of times bitcore has been observed as behind the bitcoin blockchain
 function create_counter_file() {
     TEMP_COUNTER_FILE=$(mktemp /tmp/${TEMP_COUNTER_FILE_BASE_NAME}.XXXXX)
-    echo "0" > ${TEMP_COUNTER_FILE}
+    echo -e "times failed,# of blocks behind\n0,0" > ${TEMP_COUNTER_FILE}
 }
 
 # Get the tmp counter file to use
@@ -74,26 +74,38 @@ function get_counter_file() {
     fi
 }
 
-# Get blockchain heights. Iterate the counter file if the heights don't match. Otherwise, reset the counter to 0
+# Get blockchain heights
+# Iterate the counter file if the heights don't match
+# Update the number of blocks bitcore is behind bitcoin_core
+# Otherwise, reset the counter to 0
 function compare_heights() {
     local bitcoin_core_height=$(docker logs ${BITCOIN_CORE_CONTAINER} --tail 100 | grep "height=" | cut -d '=' -f3 | awk '{print $1}' | tail -1)
     local bitcore_height=$(docker logs ${BITCORE_CONTAINER} --tail 100 | grep "height=" | cut -d '=' -f4 | tail -1)
+    local times_failed=$(cat ${TEMP_COUNTER_FILE} | tail -n 1 | cut -d',' -f1)
+    local blocks_behind_on_previous_run=$(cat ${TEMP_COUNTER_FILE} | tail -n 1 | cut -d',' -f2)
+    local blocks_behind_on_this_run=$((${bitcoin_core_height} - ${bitcore_height}))
 
     # Compare blockchain heights
     if [ "${bitcoin_core_height}" != "${bitcore_height}" ]; then
         # Increment counter file by 1
         log_info "Height discrepancy found. Incrementing counter file."
-        echo $(awk '{printf($1+1)}' ${TEMP_COUNTER_FILE}) > ${TEMP_COUNTER_FILE}
-    elif [ "${bitcoin_core_height}" = "${bitcore_height}" ]; then
-        # Reset counter file to 0
-        log_info "Heights match. Setting counter file to 0"
-        echo "0" > ${TEMP_COUNTER_FILE}
-    fi
+        sed -ri "s/([[:digit:]]),([[:digit:]])/$((${times_failed} + 1)),\2/g" ${TEMP_COUNTER_FILE}
 
-    # Restart Bitcore docker container
-    if [ $(cat ${TEMP_COUNTER_FILE}) -ge ${RESTART_THRESHOLD} ]; then
-        log_info "Threshold met. Restarting Bitcore Docker container..."
-        docker restart ${BITCORE_CONTAINER}
+        # Compare current blocks behind against previous blocks behind
+        # If the blocks are getting further behind bitcoin_core since the last execution, update the counter file
+        if [ ${blocks_behind_on_this_run} -gt ${blocks_behind_on_previous_run} ]; then
+            sed -ri "s/([[:digit:]]),([[:digit:]])/\1,${blocks_behind_on_this_run}/g" ${TEMP_COUNTER_FILE}
+
+            # Restart Bitcore docker container if where past the failure threshold
+            if [ $(cat ${TEMP_COUNTER_FILE}) -ge ${RESTART_THRESHOLD} ]; then
+                log_info "Threshold met and we're falling further behind in blocks than previous execution. Restarting Bitcore Docker container..."
+                docker restart ${BITCORE_CONTAINER}
+            fi
+        fi
+    elif [ "${bitcoin_core_height}" = "${bitcore_height}" ]; then
+        # Reset counter file to 0 runs failed and 0 blocks behind
+        log_info "Heights match. Setting counter file to 0"
+        sed -ri "s/([[:digit:]]),([[:digit:]])/0,0/g" ${TEMP_COUNTER_FILE}
     fi
 }
 

--- a/unit-files/check_health.service
+++ b/unit-files/check_health.service
@@ -1,12 +1,13 @@
-# health_checker.service
+# check_health.service
 [Unit]
-Description=Health Check Service
+Description=Check Health Service
 Requires=docker.service
 Requires=bitcore.service
 Requires=bitcoin_core.service
 Requires=create_docker_network.service
 
 [Service]
+Type=oneshot
 TimeoutStartSec=0
 Restart=on-failure
 RuntimeDirectory=bitcoind
@@ -16,7 +17,7 @@ NoNewPrivileges=true
 PrivateDevices=true
 
 ExecStartPre=-/usr/bin/rm -f /tmp/health-check*
-ExecStart=/usr/bin/bash /bitcoind/scripts/check_health.sh
+ExecStart=/usr/bin/bash /bitcoind/scripts/check_health.sh -t 10
 
 # Deny the creation of writable and executable memory mappings.
 MemoryDenyWriteExecute=true

--- a/unit-files/check_health.service
+++ b/unit-files/check_health.service
@@ -1,0 +1,25 @@
+# health_checker.service
+[Unit]
+Description=Health Check Service
+Requires=docker.service
+Requires=bitcore.service
+Requires=bitcoin_core.service
+Requires=create_docker_network.service
+
+[Service]
+TimeoutStartSec=0
+Restart=on-failure
+RuntimeDirectory=bitcoind
+PrivateTmp=true
+ProtectSystem=full
+NoNewPrivileges=true
+PrivateDevices=true
+
+ExecStartPre=-/usr/bin/rm -f /tmp/health-check*
+ExecStart=/usr/bin/bash /bitcoind/scripts/check_health.sh
+
+# Deny the creation of writable and executable memory mappings.
+MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target

--- a/unit-files/check_health.service
+++ b/unit-files/check_health.service
@@ -9,8 +9,7 @@ Requires=create_docker_network.service
 [Service]
 Type=oneshot
 
-ExecStartPre=-/usr/bin/rm -f /tmp/health-check*
-ExecStart=/usr/bin/bash /bitcoind/scripts/check_health.sh -t 10
+ExecStart=/usr/bin/bash /bitcoind/scripts/check_health.sh -t 5
 
 [Install]
 WantedBy=multi-user.target

--- a/unit-files/check_health.service
+++ b/unit-files/check_health.service
@@ -8,7 +8,6 @@ Requires=create_docker_network.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 
 ExecStartPre=-/usr/bin/rm -f /tmp/health-check*
 ExecStart=/usr/bin/bash /bitcoind/scripts/check_health.sh -t 10

--- a/unit-files/check_health.service
+++ b/unit-files/check_health.service
@@ -8,19 +8,10 @@ Requires=create_docker_network.service
 
 [Service]
 Type=oneshot
-TimeoutStartSec=0
-Restart=on-failure
-RuntimeDirectory=bitcoind
-PrivateTmp=true
-ProtectSystem=full
-NoNewPrivileges=true
-PrivateDevices=true
+RemainAfterExit=yes
 
 ExecStartPre=-/usr/bin/rm -f /tmp/health-check*
 ExecStart=/usr/bin/bash /bitcoind/scripts/check_health.sh -t 10
-
-# Deny the creation of writable and executable memory mappings.
-MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target

--- a/unit-files/check_health.timer
+++ b/unit-files/check_health.timer
@@ -1,9 +1,9 @@
 # check_health.timer
 [Unit]
-Description=Checks Bitcore performance health every minute
+Description=Checks Bitcore performance health every 10 minutes
 
 [Timer]
-OnCalendar=minutely
+OnCalendar=*:0/5
 Persistent=true
 
 [Install]

--- a/unit-files/check_health.timer
+++ b/unit-files/check_health.timer
@@ -3,7 +3,7 @@
 Description=Checks Bitcore performance health every minute
 
 [Timer]
-OnCalendar=*-*-* *:**:00
+OnCalendar=minutely
 Persistent=true
 
 [Install]

--- a/unit-files/check_health.timer
+++ b/unit-files/check_health.timer
@@ -1,8 +1,10 @@
-# bitcore.timer
+# check_health.timer
 [Unit]
-Description=Wait 5 min to start bitcore on boot
+Description=Checks Bitcore performance health every minute
 
 [Timer]
-OnBootSec=5min
+OnCalendar=*-*-* *:**:00
+Persistent=true
+
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target

--- a/unit-files/check_health.timer
+++ b/unit-files/check_health.timer
@@ -1,0 +1,8 @@
+# bitcore.timer
+[Unit]
+Description=Wait 5 min to start bitcore on boot
+
+[Timer]
+OnBootSec=5min
+[Install]
+WantedBy=multi-user.target

--- a/unit-files/mongodb.service
+++ b/unit-files/mongodb.service
@@ -34,4 +34,4 @@ ExecStopPost=-/usr/bin/docker rm -f mongodb
 ExecReload=-/usr/bin/docker restart mongodb
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=bitcore.service


### PR DESCRIPTION
* Added new unit files to check the health of the bitcore container, and restart if it's falling behind bitcoin_core.
* Added bash script to be triggered by check_health.service unit every minute
* Initially set threshold to `10`, meaning the bitcore container must be observed as behind bitcoin_core 10 times consecutively to be restarted. This can be adjusted if needed
* Tested on bitcore-003, happy path works and doesn't affect 